### PR TITLE
chore: pin all dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,10 @@ tests_require =
     tox
 install_requires =
     click >= 7.0
-    equilibrator_api
-    equilibrator_cache
-    maud@git+https://github.com/biosustain/Maud.git@master
+    equilibrator-api==0.4.5.1
+    equilibrator-cache==0.4.3
+    component-contribution==0.4.4
+    maud-metabolic-models==0.3.2
 packages = find:
 
 [options.entry_points]


### PR DESCRIPTION
Closes #8 

This PR pins the version of maud and the different packages of equilibrator. For the latter, I picked a combination of versions that work together.