### PR TITLE
Test: remove python 3.10 environment from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, flake8
+envlist = py38, py39, flake8
 
 [testenv]
 deps = 


### PR DESCRIPTION
The CI script only installs 3.8 and 3.9 and 3.10 gave a dependency issue recently so this seemed like the easiest option.